### PR TITLE
Update index.js

### DIFF
--- a/Ch07 - Work with Serverless/AWS SAR/stack-proxy/src/githubwebhook/index.js
+++ b/Ch07 - Work with Serverless/AWS SAR/stack-proxy/src/githubwebhook/index.js
@@ -91,6 +91,12 @@ exports.handler = async event => {
   }
 
   let payload;
+    
+  event.body = decodeURIComponent(event.body);
+  event.body = event.body.split('=');
+  event.body.shift();
+  event.body = event.body.join('=');    
+    
   try {
     payload = JSON.parse(event.body);
   } catch (error) {


### PR DESCRIPTION
fix: Seems like Github changed the encoding of payload.body. This change is necessary to JSON.parse(event.body) work