### PR TITLE
fix: 503 problem in CloudFront

### DIFF
--- a/Ch07 - Work with Serverless/AWS SAR/stack-proxy/template.yaml
+++ b/Ch07 - Work with Serverless/AWS SAR/stack-proxy/template.yaml
@@ -149,9 +149,7 @@ Resources:
                   - s3:GetObject
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${DefaultBucket}
-                  - !Sub arn:aws:s3:::${DefaultBucket}/*
-                  - arn:aws:s3:::*
+                  - '*'
               - Effect: Allow
                 Action:
                   - dynamodb:GetItem


### PR DESCRIPTION
This change is necessary to fix the problem that I was experiecing: 503 in CloudFront, because the Lambda@Edge doesn't have privileges to access the bucket created by stack-proxy instances.

The proposed solution is sub-optimal, I think that a better solution is the ${DefaultBucket} be used by all stack-proxy instances. But, for the sake of this lab, I think that it is an interesting solution.